### PR TITLE
feat(tests): drop python3.4 support; add django 3.0

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,15 @@
 [tox]
 envlist =
-  py{34,35,36}-django111,
-  py{34,35,36,37,38}-django20,
+  py{35,36}-django111,
+  py{35,36,37,38}-django20,
   py{35,36,37,38}-django21,
   py{35,36,37,38}-django22,
+  py{36,37,38}-django30,
   py{36,37,38}-djangomaster,
 
 [testenv]
 whitelist_externals = make
 basepython =
-  py34: python3.4
   py35: python3.5
   py36: python3.6
   py37: python3.7
@@ -27,6 +27,7 @@ deps =
   django20: Django~=2.0
   django21: Django~=2.1
   django22: Django~=2.2a1
+  django30: Django~=3.0
   djangomaster: https://github.com/django/django/archive/master.tar.gz
 
 commands = make coverage


### PR DESCRIPTION
Hey! [Python 3.4 has reached end-of-life](https://www.python.org/downloads/release/python-3410/) in March. Running the tests for it fails with an installation error:

    tox_1  |   ERROR: Could not find a version that satisfies the requirement graphql-core-next<3.0.0 (from ariadne==0.6.0->-r requirements/test.txt (line 1)) (from versions: 1.0.0rc1)
    tox_1  | ERROR: No matching distribution found for graphql-core-next<3.0.0 (from ariadne==0.6.0->-r requirements/test.txt (line 1))

I've taken the liberty to drop support for python 3.4, and have added Django 3.0 to the list of testable versions.