### PR TITLE
update utils.py

### DIFF
--- a/django_ariadne_jwt/resolvers.py
+++ b/django_ariadne_jwt/resolvers.py
@@ -7,7 +7,7 @@ from .exceptions import (
     MaximumTokenLifeReachedError,
 )
 from .utils import create_jwt, decode_jwt, refresh_jwt
-
+#trying to maintain a dead repo
 
 auth_token_definition = gql(
     """

--- a/django_ariadne_jwt/utils.py
+++ b/django_ariadne_jwt/utils.py
@@ -71,7 +71,7 @@ def create_jwt(user, extra_payload={}):
 
     payload = {
         **extra_payload,
-        "user": user.username,
+        "user": (user, get_user_model().USERNAME_FIELD),
         "iat": int(now.timestamp()),
         "exp": int((now + expiration_delta).timestamp()),
     }


### PR DESCRIPTION
hi, isn't it better to use User USERNAME_FIELD for user key in create_jwt payload, for example i have my User model that it doesn't have username field and when i request for jwt token it use None for user field in payload, so when i want to get refresh token, jwt decode my token to {user:None} and graphql return me Null for refresh token because "User not found".