### PR TITLE
Add support for PyJWT 2.0.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,6 @@
 Django Ariadne JWT
 ==================
 
-|Pypi|
-
 Support for JWT based authentication for use with the ariadne_ graphql library
 running inside a Django_ project. It is heavily inspired by django-graph-jwt_.
 

--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,7 @@ First add ``JSONWebTokenBackend`` to your *AUTHENTICATION_BACKENDS*
 Then add ``JSONWebTokenMiddleware`` to your view
 
 .. code:: python
+
     from ariadne.contrib.django.views import GraphQLView, MiddlewareManager
     from django_ariadne_jwt.middleware import JSONWebTokenMiddleware
 

--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ First add ``JSONWebTokenBackend`` to your *AUTHENTICATION_BACKENDS*
 Then add ``JSONWebTokenMiddleware`` to your view
 
 .. code:: python
-
+    from ariadne.contrib.django.views import GraphQLView, MiddlewareManager
     from django_ariadne_jwt.middleware import JSONWebTokenMiddleware
 
     urlpatterns = [
@@ -38,7 +38,7 @@ Then add ``JSONWebTokenMiddleware`` to your view
           "graphql/",
           csrf_exempt(
               GraphQLView.as_view(
-                  schema=schema, middleware=[JSONWebTokenMiddleware()]
+                  schema=schema, middleware=MiddlewareManager([JSONWebTokenMiddleware()])
               )
           ),
           name="graphql"

--- a/django_ariadne_jwt/utils.py
+++ b/django_ariadne_jwt/utils.py
@@ -76,8 +76,11 @@ def create_jwt(user, extra_payload={}):
         "exp": int((now + expiration_delta).timestamp()),
     }
 
-    return jwt.encode(payload, settings.SECRET_KEY).decode("utf-8")
-
+    token = jwt.encode(payload, settings.SECRET_KEY)
+    # As of v2.0.0, PyJWT tokens are returned as string instead of a byte string
+    if isinstance(token, bytes):
+        return token.decode("utf-8")
+    return token
 
 def refresh_jwt(token):
     """Refreshes a JWT if possible"""

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,15 @@
 [tox]
 envlist =
-  py{34,35,36}-django111,
-  py{34,35,36,37,38}-django20,
+  py{35,36}-django111,
+  py{35,36,37,38}-django20,
   py{35,36,37,38}-django21,
   py{35,36,37,38}-django22,
+  py{36,37,38}-django30,
   py{36,37,38}-djangomaster,
 
 [testenv]
 whitelist_externals = make
 basepython =
-  py34: python3.4
   py35: python3.5
   py36: python3.6
   py37: python3.7
@@ -27,6 +27,7 @@ deps =
   django20: Django~=2.0
   django21: Django~=2.1
   django22: Django~=2.2a1
+  django30: Django~=3.0
   djangomaster: https://github.com/django/django/archive/master.tar.gz
 
 commands = make coverage


### PR DESCRIPTION
As of v2.0.0, PyJWT tokens are returned as string instead of a byte string (see jpadilla/pyjwt#529). This PR adds support for PyJWT 2.0.0.